### PR TITLE
Fix format scopes, they should be of type /auth/#{scope}

### DIFF
--- a/lib/omniauth/strategies/gplus.rb
+++ b/lib/omniauth/strategies/gplus.rb
@@ -7,7 +7,7 @@ module OmniAuth
         token_url: 'https://www.google.com/accounts/o8/oauth2/token'
       }
 
-      option :scope, 'email'
+      option :scope, 'userinfo.email'
 
       option :uid_field, :uid
       
@@ -51,7 +51,7 @@ module OmniAuth
       end
 
       def format_scope(scope)
-        "https://www.googleapis.com/auth/userinfo.#{scope}"
+        "https://www.googleapis.com/auth/#{scope}"
       end
 
       def custom_parameters(params)

--- a/test/lib/omniauth/strategies/gplus_test.rb
+++ b/test/lib/omniauth/strategies/gplus_test.rb
@@ -31,7 +31,7 @@ class TestOmniAuthGPlus < MiniTest::Unit::TestCase
   end
 
   def test_default_scope_is_email
-    expected = 'email'
+    expected = 'userinfo.email'
     actual = strategy.options['scope']
     assert_equal(expected, actual)
   end


### PR DESCRIPTION
Scopes should be based on /auth/, no /auth/userinfo.

According to https://developers.google.com/+/api/oauth#scopes, valid
scopes are:

```
- https://www.googleapis.com/auth/plus.login
- https://www.googleapis.com/auth/plus.me
- https://www.googleapis.com/auth/userinfo.email
```

So you should not scopes start with `userinfo.` ...
