### PR TITLE
quickfix redirect_url for issue #25

### DIFF
--- a/lib/omniauth/strategies/gplus.rb
+++ b/lib/omniauth/strategies/gplus.rb
@@ -45,7 +45,7 @@ module OmniAuth
         }
       end
 
-      # move it here...
+      # this overwrite was removed from Omniauth::Strategies::OAuth2
       def callback_url
         full_host + script_name + callback_path
       end

--- a/lib/omniauth/strategies/gplus.rb
+++ b/lib/omniauth/strategies/gplus.rb
@@ -45,6 +45,11 @@ module OmniAuth
         }
       end
 
+      # move it here...
+      def callback_url
+        full_host + script_name + callback_path
+      end
+
       def authorize_params
         super.tap do |params|
           params['scope'] = format_scopes(params['scope'])


### PR DESCRIPTION
the overwrite redirect_url was removed from omniauth-oauth2 - cause it obviously conflicted with query-strings...
so if a query string is necessary for a implemented gplus strategy this PR isn't the right thing - allthough it just recreates the functionality as it was with omniauth-oauth2 1.3.1
