### PR TITLE
Expose is_default to info hash's image key hash

### DIFF
--- a/lib/omniauth/strategies/gplus.rb
+++ b/lib/omniauth/strategies/gplus.rb
@@ -29,7 +29,7 @@ module OmniAuth
           'name' => raw_info['name'],
           'first_name' => raw_info['given_name'],
           'last_name' => raw_info['family_name'],
-          'image' => raw_info['picture'],
+          'image' => { 'url' => raw_info['picture'], 'is_default' => is_default },
           'urls' => {
             'Google+' => raw_info['link']
           }
@@ -92,6 +92,13 @@ module OmniAuth
       def raw_info
         access_token.options[:mode] = :query
         @raw_info ||= access_token.get('userinfo').parsed
+      end
+
+      def is_default
+        return @is_default if defined?(@is_default)
+
+        url = File.join('https://www.googleapis.com/plus/v1/people', raw_info['id'])
+        @is_default = access_token.get(url).parsed['image']['isDefault']
       end
     end
   end


### PR DESCRIPTION
Expose the `isDefault` from [Google+ People API](https://developers.google.com/+/web/api/rest/latest/people/get), this parameter we can know if the Google+ avatar is default (google generated)  or user uploaded.

Before

```
{ ‘image’ => 'image url on gplus' }
```

After

```
image => {
  'url' => 'image url on gplus',
  'is_default' => true / false
}
```

- [ ] Is this the right way to do it?
- [ ] Do we want to keep it compatible / a major version bump (breaking change)
- [ ] Add tests