### PR TITLE
Update `authorize_url` and `token_url`

### DIFF
--- a/lib/omniauth/strategies/gplus.rb
+++ b/lib/omniauth/strategies/gplus.rb
@@ -8,8 +8,8 @@ module OmniAuth
 
       option :client_options,
              :site => 'https://www.googleapis.com/oauth2/v1',
-             :authorize_url => 'https://www.google.com/accounts/o8/oauth2/authorization',
-             :token_url => 'https://www.google.com/accounts/o8/oauth2/token'
+             :authorize_url => 'https://accounts.google.com/o/oauth2/auth',
+             :token_url => 'https://www.googleapis.com/oauth2/v4/token'
 
       option :authorize_options, [:scope, :request_visible_actions]
 


### PR DESCRIPTION
The old `authorize_url`, `https://www.google.com/accounts/o8/oauth2/authorization`, redirects to `https://accounts.google.com/o/oauth2/auth`.

The old `token_url` began 404'ing some time in the past few days-- the current recommended URL is `https://www.googleapis.com/oauth2/v4/token` (according to https://developers.google.com/identity/protocols/OpenIDConnect).